### PR TITLE
replace exec in removeGitRepositories with Symfony Finder & FileSystem

### DIFF
--- a/src/composer/ScriptHandler.php
+++ b/src/composer/ScriptHandler.php
@@ -4,6 +4,7 @@ namespace Varbase\composer;
 
 use Composer\Semver\Comparator;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Composer\EventDispatcher\Event;
 
 /**
@@ -109,7 +110,13 @@ class ScriptHandler {
    */
   public static function removeGitDirectories() {
     $drupal_root = static::getDrupalRoot(getcwd());
-    exec("find " . $drupal_root . " -name '.git' | xargs rm -rf");
+    $gitDirs = new Finder();
+    $gitDirs->directories()->ignoreVCS(false)->ignoreDotFiles(false)->in($drupal_root)->name('.git');
+
+    if ($gitDirs->count()) {
+      $fs = new Filesystem();
+      $fs->remove($gitDirs);
+    }
   }
 
   /**


### PR DESCRIPTION
The exec('findd..') method is working different on Windows vs Unix systems.
Therefore I rewrote the function using the Symfony Finder & FileSystem components.

Tested on my Mac, will test in monday on a Windows machine