### PR TITLE
Allow Metatag to be updated from v1.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "drupal/tour_builder": "1.x-dev#d70e898949b7ec4095efb391a0dbec56d0117558",
     "drupal/pathauto": "1.2",
     "drupal/redirect": "1.2",
-    "drupal/metatag": "1.5",
+    "drupal/metatag": "^1.5",
     "drupal/schema_metatag": "1.3",
     "drupal/simple_sitemap": "2.12",
     "drupal/google_analytics": "2.3",


### PR DESCRIPTION
This allows Metatag to be updated from 1.5 to the newest v1 release, matching what is in varbase_seo.