### PR TITLE
Renamed Google+ to Google in installer

### DIFF
--- a/configbit/extra.components.varbase.bit.yml
+++ b/configbit/extra.components.varbase.bit.yml
@@ -36,7 +36,7 @@ config_bit:
           config_form: false
         varbase_auth:
           title: "Varbase Social Single Sign-On"
-          description: "Adds single sign-on using existing information from a social networking service such as Facebook, Twitter or Google+. Built using <a href=\"https://www.drupal.org/project/social_api\" target=\"_blank\">Social API</a>."
+          description: "Adds single sign-on using existing information from a social networking service such as Facebook, Twitter or Google. Built using <a href=\"https://www.drupal.org/project/social_api\" target=\"_blank\">Social API</a>."
           selected: false
           config_form: true
           formbit: "src/FormBit/varbase_auth.formbit.php"

--- a/src/FormBit/varbase_auth.formbit.php
+++ b/src/FormBit/varbase_auth.formbit.php
@@ -39,7 +39,7 @@ function varbase_auth_build_formbit(array &$formbit, FormStateInterface &$form_s
     '#title' => t('Social authentications to enable'),
     '#default_value' => ['social_auth_google'],
     '#options' => [
-      'social_auth_google' => t('Google +'),
+      'social_auth_google' => t('Google'),
       'social_auth_facebook' => t('Facebook'),
       'social_auth_linkedin' => t('Linkedin'),
       'social_auth_twitter' => t('Twitter'),


### PR DESCRIPTION
The new Social Auth Google version switched to use Google API instead of Google+ since this has been deprecated.
This is just to change the name in the installer.