### PR TITLE
Remove automatic removal of Git directories: vendor libs are no longer included in git.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,12 +98,10 @@
     "pre-install-cmd": ["Varbase\\composer\\ScriptHandler::checkComposerVersion"],
     "pre-update-cmd": ["Varbase\\composer\\ScriptHandler::checkComposerVersion"],
     "post-install-cmd": [
-      "Varbase\\composer\\ScriptHandler::createRequiredFiles",
-      "Varbase\\composer\\ScriptHandler::removeGitDirectories"
+      "Varbase\\composer\\ScriptHandler::createRequiredFiles"
     ],
     "post-update-cmd": [
-      "Varbase\\composer\\ScriptHandler::createRequiredFiles",
-      "Varbase\\composer\\ScriptHandler::removeGitDirectories"
+      "Varbase\\composer\\ScriptHandler::createRequiredFiles"
     ],
     "post-drupal-scaffold-cmd": ["Varbase\\composer\\ScriptHandler::postDrupalScaffoldProcedure"]
   },

--- a/src/composer/ScriptHandler.php
+++ b/src/composer/ScriptHandler.php
@@ -118,20 +118,6 @@ class ScriptHandler {
   }
 
   /**
-   * Remove .git folder from modules, themes, profiles of development branches.
-   */
-  public static function removeGitDirectories() {
-    $drupal_root = static::getDrupalRoot(getcwd());
-
-    if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
-      self::removeWindowsGitDirectories($drupal_root);
-    }
-    else {
-      exec("find " . $drupal_root . " -name '.git' | xargs rm -rf");
-    }
-  }
-
-  /**
    * Post Drupal Scaffold Procedure.
    *
    * @param \Composer\EventDispatcher\Event $event


### PR DESCRIPTION
I was struggling to develop `varbase-project` with `drupal/vardot_support` and `drupal/site_audit`, etc.

No matter what I did in composer version, I lost my git checkouts!

Then I saw `removeGitDirectories` :)

I think this feature was more useful when vendor and core wasn't git ignored... Composer handles this pretty well now with `--prefer-dist` or `--prefer-source`.

This script is called in varbase and in varbase project.

This PR removes it from the varbase drupal install profile.

Stand by to a PR to remove it from varbase-project.